### PR TITLE
Client builder improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,11 @@ Add the following to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-lastfm = "0.1.0"
+lastfm = "*"
 ```
+
+Replace the `*` with the actual version you want to use.
+
 
 Alternatively you can run:
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,8 +6,11 @@
 //!
 //! ```toml
 //! [dependencies]
-//! lastfm = "0.1.0"
+//! lastfm = "*"
 //! ```
+//!
+//! Replace the `*` with the actual version you want to use.
+//!
 //!
 //! Alternatively you can run:
 //!

--- a/src/retry_delay.rs
+++ b/src/retry_delay.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 
 pub(crate) struct RetryDelay {
     n: usize,
@@ -10,6 +10,12 @@ pub(crate) struct RetryDelay {
 impl RetryDelay {
     pub fn new(max_retry: usize) -> Self {
         Self { n: 0, max_retry }
+    }
+}
+
+impl Default for RetryDelay {
+    fn default() -> Self {
+        RetryDelay::new(5)
     }
 }
 


### PR DESCRIPTION
Makes the client more configurable:

- You can configure your own underlying `reqwest` client
- You can change the base URL (e.g. for local testing, mocking, etc)