### PR TITLE
Refactor builder pattern for ClientBuilder

### DIFF
--- a/examples/customise_client.rs
+++ b/examples/customise_client.rs
@@ -1,0 +1,16 @@
+use lastfm::ClientBuilder;
+use std::env;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let api_key = env::var("LASTFM_API_KEY")?;
+
+    let mut client_builder = ClientBuilder::new(api_key, "loige".to_string());
+    client_builder.reqwest_client(reqwest::Client::new());
+    client_builder.base_url("http://localhost:8080".parse().unwrap());
+    let client = client_builder.build();
+
+    // do something with client...
+
+    Ok(())
+}

--- a/examples/customise_client.rs
+++ b/examples/customise_client.rs
@@ -5,12 +5,13 @@ use std::env;
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let api_key = env::var("LASTFM_API_KEY")?;
 
-    let mut client_builder = ClientBuilder::new(api_key, "loige".to_string());
-    client_builder.reqwest_client(reqwest::Client::new());
-    client_builder.base_url("http://localhost:8080".parse().unwrap());
-    let client = client_builder.build();
+    let client = ClientBuilder::new(api_key, "loige")
+        .reqwest_client(reqwest::Client::new())
+        .base_url("http://localhost:8080".parse().unwrap())
+        .build();
 
     // do something with client...
+    dbg!(client);
 
     Ok(())
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -26,6 +26,7 @@ lazy_static! {
         .expect("Cannot initialize HTTP client");
 }
 
+// TODO: store A & U as String and keep the AsRef<str> only in the constructors
 pub struct ClientBuilder<A: AsRef<str>, U: AsRef<str>> {
     api_key: A,
     username: U,
@@ -43,6 +44,7 @@ impl<A: AsRef<str>, U: AsRef<str>> ClientBuilder<A, U> {
         }
     }
 
+    // TODO: the &mut self makes it impossible to use the builder pattern (chain calls)
     pub fn reqwest_client(&mut self, client: reqwest::Client) -> &mut Self {
         self.reqwest_client = Some(client);
         self
@@ -181,6 +183,7 @@ async fn get_page<A: AsRef<str>, U: AsRef<str>>(
 }
 
 impl Client {
+    // TODO: move these 2 functions to the builder (or have similar ones in the builder too)
     pub fn from_env<U: AsRef<str>>(username: U) -> Self {
         Self::try_from_env(username).unwrap()
     }


### PR DESCRIPTION
- Allows proper chaining of methods
- simplify types by internally storing `username` and `api_key` as Strings and only accept `AsRef<str>` in the constructors
- have `from_env` and `try_from_env` methods also in `ClientBuilder()`