### PR TITLE
Cloneable client

### DIFF
--- a/examples/customise_retry_strategy.rs
+++ b/examples/customise_retry_strategy.rs
@@ -1,5 +1,5 @@
 use lastfm::{retry_strategy::RetryStrategy, Client};
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
 /// A retry strategy that will retry 3 times with the following delays:
 /// - Retry 0: 0 second delay
@@ -26,7 +26,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let client = Client::builder()
         .api_key("some-api-key".to_string())
         .username("loige".to_string())
-        .retry_strategy(Box::from(retry_strategy))
+        .retry_strategy(Arc::new(retry_strategy))
         .build();
 
     // do something with client...

--- a/src/client.rs
+++ b/src/client.rs
@@ -223,17 +223,7 @@ impl<A: AsRef<str>, U: AsRef<str>> Client<A, U> {
 
     /// Fetches the currently playing track for the user (if any)
     pub async fn now_playing(&self) -> Result<Option<NowPlayingTrack>, Error> {
-        let page = get_page(GetPageOptions {
-            client: &self.reqwest_client,
-            retry_strategy: &*self.retry_strategy,
-            base_url: &self.base_url,
-            api_key: self.api_key.as_ref(),
-            username: self.username.as_ref(),
-            limit: 1,
-            from: None,
-            to: None,
-        })
-        .await?;
+        let page = self.get_page_helper(1, None, None).await?;
 
         match page.tracks.first() {
             Some(Track::NowPlaying(t)) => Ok(Some(t.clone())),
@@ -254,17 +244,7 @@ impl<A: AsRef<str>, U: AsRef<str>> Client<A, U> {
         from: Option<i64>,
         to: Option<i64>,
     ) -> Result<RecentTracksFetcher, Error> {
-        let page = get_page(GetPageOptions {
-            client: &self.reqwest_client,
-            retry_strategy: &*self.retry_strategy,
-            base_url: &self.base_url,
-            api_key: self.api_key.as_ref(),
-            username: self.username.as_ref(),
-            limit: 200,
-            from,
-            to,
-        })
-        .await?;
+        let page = self.get_page_helper(200, from, to).await?;
 
         let mut fetcher = RecentTracksFetcher {
             api_key: self.api_key.as_ref().to_string(),
@@ -281,5 +261,30 @@ impl<A: AsRef<str>, U: AsRef<str>> Client<A, U> {
         fetcher.update_current_page(page);
 
         Ok(fetcher)
+    }
+
+
+    /// Simple helper method for getting a page of recent tracks.
+    ///
+    /// Parameterizes options that need to change from method to method and re-uses the logic for passing other fields like the retry strategy and api key.
+    /// 
+    /// The `limit` parameter is the upper-bound on results in the page. The `from` and `to` parameters are Unix timestamps (in seconds).
+    async fn get_page_helper(
+        &self,
+        limit: u32,
+        from: Option<i64>,
+        to: Option<i64>,
+    ) -> Result<RecentTracksPage, Error> {
+        get_page(GetPageOptions {
+            client: &self.reqwest_client,
+            retry_strategy: &*self.retry_strategy,
+            base_url: &self.base_url,
+            api_key: self.api_key.as_ref(),
+            username: self.username.as_ref(),
+            limit: limit,
+            from,
+            to,
+        })
+        .await
     }
 }


### PR DESCRIPTION
:wave: 

For some context, I'm using the Last.fm `Client` in an [`axum`](https://docs.rs/axum/latest/axum) web server, and a common pattern is to stick dependencies in a shared [`State`](https://docs.rs/axum/latest/axum/extract/struct.State.html) struct so that every route in your server has access to these dependencies. However, the struct must implement `Clone` so that it can be copied into each route, and even if I stick the `Client` into an `Arc`, I can't guarantee that I can safely take ownership of the underlying `Client` in order to call the `all_tracks` or `recent_tracks` methods.

